### PR TITLE
Added link of Python Developer Roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@
 - *Python Cookbook* by David Beazley & Brian K. Jones [English 3rd Edition](http://www.amazon.com/Python-Cookbook-Third-David-Beazley/dp/1449340377)
 - *Python Essential Reference* by David M. Beazley [English 4th Edition](http://www.amazon.com/Python-Essential-Reference-4th-Edition/dp/0672329786)
 - *Python in a Nutshell* by Alex Martelli [English 2nd Edition](http://www.amazon.com/Python-Nutshell-Second-Edition-In/dp/0596100469)
+- *Python Developer Roadmap* by Kamran Ahmed [Python Developer Roadmap](https://roadmap.sh/python)
 
 ## Data Structures and Algorithms
 - *Classic Computer Science Problems in Python* by David Kopec [English Edition](https://www.manning.com/books/classic-computer-science-problems-in-python)


### PR DESCRIPTION
Hi @junnplus,

I came across your repository [awesome-python-books](https://github.com/junnplus/awesome-python-books) and found it to be a valuable resource for Python enthusiasts.

While browsing through the repository, I noticed that it was missing links to any structured guides such as the famous ["Python Developer Roadmap"](https://roadmap.sh/python). I took the initiative to submit a ["Pull Request"](https://github.com/junnplus/awesome-python-books/pull/35) adding it in references section.

Thank you for your time and effort in maintaining this valuable resource :)

Best,
Mouaaz