### PR TITLE
changed think python to 3rd edition

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 ### Primary
 - *The Quick Python Book* by Naomi Ceder [English 3rd Edition](https://www.amazon.com/Quick-Python-Book-Naomi-Ceder/dp/1617294039)
 - *Beginning Python: from Novice to Professional* by Magnus Lie Hetland [English 2nd Edition](http://www.amazon.com/Beginning-Python-Professional-Experts-Professionals/dp/1590599829)
-- *Think Python: How to Think Like a Computer Scientist* by Allen B. Downey [English 2nd Edition](http://www.amazon.com/Think-Python-Like-Computer-Scientist/dp/1491939362)
+- *Think Python: How to Think Like a Computer Scientist* by Allen B. Downey [English 3rd Edition](https://www.amazon.in/Think-Python-Like-Computer-Scientist/dp/1098155432)
 - *Learning Python* by Mark Lutz [English 5th Edition](http://www.amazon.com/Learning-Python-Edition-Mark-Lutz/dp/1449355730)
 - *Programming Python* by Mark Lutz [English 4th Edition](http://www.amazon.com/gp/product/0596158106)
 - *Core Python Programming* by Wesley Chun [English 2nd Edition](http://www.amazon.com/Core-Python-Programming-Wesley-Chun/dp/0132269937)


### PR DESCRIPTION
A new edition of Think Python is out. It is available freely on the internet in form of Jupyter Notebooks so the link can also be replaced with the Notebook links as well.
https://allendowney.github.io/ThinkPython/